### PR TITLE
DevCompanion: opinionated hacky changes

### DIFF
--- a/src/plugins/devCompanion.dev/initWs.tsx
+++ b/src/plugins/devCompanion.dev/initWs.tsx
@@ -212,6 +212,7 @@ export function initWs(isManual = false) {
                                 let results: any[];
                                 switch (findType.replace("find", "").replace("Lazy", "")) {
                                     case "":
+                                    case "Component":
                                         results = findAll(parsedArgs[0]);
                                         break;
                                     case "ByProps":
@@ -317,6 +318,7 @@ export function initWs(isManual = false) {
                     let results: any[];
                     switch (type.replace("find", "").replace("Lazy", "")) {
                         case "":
+                        case "Component":
                             results = findAll(parsedArgs[0]);
                             break;
                         case "ByProps":

--- a/src/plugins/devCompanion.dev/util.tsx
+++ b/src/plugins/devCompanion.dev/util.tsx
@@ -94,7 +94,7 @@ export function findModuleId(find: CodeFilter) {
         throw new Error("No Matches Found");
     }
     if (matches.length !== 1) {
-        throw new Error("More than one match");
+        throw new Error(`This filter matches ${matches.length} modules. Make it more specific!`);
     }
     return matches[0];
 }


### PR DESCRIPTION
makes findComponentLazy work and adds verbose count when too many modules are found, text stolen from ConsoleShortcuts