### PR TITLE
fix(EmoteCloner): the animated emoji won't be animated after cloned

### DIFF
--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -310,7 +310,10 @@ function buildMenuItem(type: "Emoji" | "Sticker", fetchData: () => Promisable<Om
 }
 
 function isGifUrl(url: string) {
-    return new URL(url).pathname.endsWith(".gif");
+    const _url = new URL(url);
+    const isEndWithGif = _url.pathname.endsWith(".gif");
+    const isAnimatedSet = _url.searchParams.get("animated") === "true";
+    return isEndWithGif || isAnimatedSet;
 }
 
 const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {


### PR DESCRIPTION
Hi! Thank you for making this awesome plugin. I noticed a small issue with the emoji URL detection and wanted to help fix it

I found out that the url structure for the emoji has changed.
So I modified the function `isGifUrl` to detect animated emojis by checking for `animated=true` in the URL search parameters.

Hope this would help.